### PR TITLE
Fix missing Color.Color import in Line.elm

### DIFF
--- a/src/Component/Line.elm
+++ b/src/Component/Line.elm
@@ -6,6 +6,7 @@ import Time exposing (Time)
 import List
 import Text
 import Mouse
+import Color exposing (Color)
 import AnimationFrame
 
 import Config.Size exposing (seriesWidth, seriesHeight)


### PR DESCRIPTION
Noticed the build was failing, this seems to be the culprit. Removed by mistake, maybe? 

I have a talk tomorrow on Elm and I'd like to get this fixed so I can use it. :smile: 
