### PR TITLE
Update deploy script to include the build output

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,5 +24,6 @@ git init
 git config user.name "Travis-CI"
 git config user.email "travis@yang-wei.com"
 git add .
+git add --force build/main.js
 git commit -m "Deploy to GitHub Pages"
 git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 2>&1


### PR DESCRIPTION
Since the build directory is .gitignore'd the generated main.js is not committed in the deploy script, thus breaking the gh-pages output
